### PR TITLE
include currency and description in capture

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
   "require": {
     "php": "^7.0",
     "bytic/omnipay-common": "^3.0",
-    "paylike/php-api": "^1.0"
+    "paylike/php-api": "^1.0",
+    "ext-json": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0|^9.0",

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -12,4 +12,13 @@ class Helper
     {
         return __DIR__ . '/resources/views/';
     }
+
+    /**
+     * @param string $descriptor
+     * @return bool
+     */
+    public static function validateDescriptor($descriptor){
+        //https://github.com/paylike/descriptor#how-is-it-validated
+        return false !== preg_match('/^[\x20-\x7E]{0,22}$/', $descriptor);
+    }
 }

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -2,6 +2,7 @@
 
 namespace ByTIC\Omnipay\Paylike\Message;
 
+use ByTIC\Omnipay\Paylike\Helper;
 use ByTIC\Omnipay\Paylike\Traits\HasApiTrait;
 
 /**
@@ -24,22 +25,66 @@ class CaptureRequest extends AbstractRequest
 
         $data = ['success' => false];
 
+        $parameters = [
+            'amount' => $this->getAmount() * 100,
+        ];
+
+        //optionals
+        $currency = $this->getParameter('currency');
+        if (is_string($currency) && strlen($currency) === 3) {
+            $parameters['currency'] = $currency;
+        }
+        $descriptor = $this->getParameter('descriptor');
+        if (is_string($descriptor)) {
+            if(Helper::validateDescriptor($descriptor)){
+                throw new \Omnipay\Common\Exception\InvalidRequestException("The descriptor does not conform to requirements.");
+            }
+            $parameters['descriptor'] = $descriptor;
+        }
+
+
         try {
             $transactions = $this->getApi()->transactions();
             $transaction = $transactions->capture(
                 $this->getTransactionId(),
-                [
-                    'amount' => $this->getAmount() * 100,
-//                    'currency' => 'EUR'
-                ]
+                $parameters
             );
             if (is_array($transaction)) {
                 $data['transaction'] = $transaction;
                 $data['success'] = true;
             }
         } catch (\Paylike\Exception\NotFound $e) {
+            //The transaction was not found
+            $data['exception_class'] = "\Paylike\Exception\NotFound";
             $data['message'] = "The transaction was not found";
+
+        } catch (\Paylike\Exception\InvalidRequest $e) {
+            // Bad (invalid) request - see $e->getJsonBody() for the error
+            $data['exception_class'] = "\Paylike\Exception\InvalidRequest";
+            $data['message'] = "Bad (invalid) request - ".substr(json_encode($e->getJsonBody()), 0, 250 );
+
+        } catch (\Paylike\Exception\Forbidden $e) {
+            // You are correctly authenticated but do not have access.
+            $data['exception_class'] = "\Paylike\Exception\Forbidden";
+            $data['message'] = "You are correctly authenticated but do not have access.";
+
+        } catch (\Paylike\Exception\Unauthorized $e) {
+            // You need to provide credentials (an app's API key)
+            $data['exception_class'] = "\Paylike\Exception\Unauthorized";
+            $data['message'] = "You need to provide credentials (an app's API key)";
+
+        } catch (\Paylike\Exception\Conflict $e) {
+            // Everything you submitted was fine at the time of validation, but something changed in the meantime and came into conflict with this (e.g. double-capture).
+            $data['exception_class'] = "\Paylike\Exception\Conflict";
+            $data['message'] = "Everything you submitted was fine at the time of validation, but something changed in the meantime and came into conflict with this (e.g. double-capture)";
+
+        } catch (\Paylike\Exception\ApiConnection $e) {
+            // Network error on connecting via cURL
+            $data['exception_class'] = "\Paylike\Exception\ApiConnection";
+            $data['message'] = "Network error on connecting via cURL";
+
         } catch (\Paylike\Exception\ApiException $e) {
+            $data['exception_class'] = "\Paylike\Exception\ApiException";
             $data['message'] = "Api Error:" . $e->getMessage();
         }
 


### PR DESCRIPTION
Without currency on server side, it is possible to change currency in javascript.
That is a big problem, when the goods are immediately delivered electronicaly.

In this PR I added to currency and descripto to capture request.
And I added other exceptions according to https://github.com/paylike/php-api#error-handling .